### PR TITLE
Add SAN field to the x509 certificate

### DIFF
--- a/golang/examples/tls_test.go
+++ b/golang/examples/tls_test.go
@@ -60,6 +60,7 @@ func createECDSASelfSignedCert(privKey *util.EP11PrivateKey, commonName string, 
 		Subject: pkix.Name{
 			CommonName: commonName,
 		},
+		DNSNames: []string{commonName},
 		NotBefore: time.Now(),
 		NotAfter:  time.Now().Add(time.Hour * 24 * 180),
 	}


### PR DESCRIPTION
I was getting the following error when running the TLS example: 
```
=== RUN   Example_tls
2020/09/29 13:48:13 http: TLS handshake error from [::1]:63266: remote error: tls: bad certificate
--- FAIL: Example_tls (0.94s)
got:
Ping failed: Http client get failed: Get "https://localhost:63265": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```

This patch adds the SAN field to the x509 certificate so it doesn't rely just on legacy Common Name field to fix this error.

